### PR TITLE
Allow external configuration file

### DIFF
--- a/spki
+++ b/spki
@@ -28,6 +28,12 @@ INTRMDT_CRL_DP=''
 ROOT_OCSP=''
 INTRMDT_OCSP=''
 
+CONFIGPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+CONFIGFILE=$( basename $0 )
+if [ -e ${CONFIGPATH}/${CONFIGFILE}.conf ]; then
+       . ${CONFIGPATH}/${CONFIGFILE}.conf
+fi
+
 #############
 # End Config
 #############


### PR DESCRIPTION
An external configuration file can be useful:
 * For someone that may not wish to modify the original spki file (which can create issues when merging future updates) from the repo in order to configure the app
 * If you want to use the spki script for multiple certificates by using a symbolic link for the spki script (or even copying the spki script)

This patch will obey symbolic links, as well as any changes to the name of the script so either of these methods could be used:
```
    mkdir companyname
    cd companyname
    ln -s ../spki-master/spki spki
    cat << EOF >> spki.conf
    ROOT_DIR='/path/to/data/folder'
    ROOT_CRL_DP=''
    EOF
    ./spki
```
or
```
    ln -s spki-master/spki spki-company
    cat << EOF >> spki-company.conf
    ROOT_DIR='/path/to/data/folder'
    ROOT_CRL_DP=''
    EOF
    ./spki-company
```

and it will override these config settings for when it's run from a script in that folder.  This works whether you run it in the current folder or using a relative or absolute path.  If the file doesn't exist, it will use the old behaviour.