### PR TITLE
Spaces in OrgName treated as delimiter due to missed quotes

### DIFF
--- a/spki
+++ b/spki
@@ -589,7 +589,7 @@ get-default-fields() {
 			orgNames=($RESPONSE)
 			unset IFS
 			orgCount=0
-			for orgName in ${orgNames[@]}; do
+			for orgName in "${orgNames[@]}"; do
 				if [[ "$orgName" != '.' ]]; then
 					DEFAULT_FIELDS+=$'\n'"${orgCount}.organizationName = Organization Name $orgCount"
 					if [[ -n "$orgName" ]]; then


### PR DESCRIPTION
Spaces in OrgName treated as delimiter due to missed quotes

Using bash 5.0.3(1), as distributed in Debian (unsure if it impacts other systems).

$ ./spki init
...
        Organization Names (organizationName), separated by ';':Company Company Ltd.
...
        Common Name []:
        Country Name (2 letter code) [US]:
        State or Province Name [State]:
        Locality Name [City]:
        Organization Name 0 [Company]:
        Organization Name 1 [Company]:
        Organization Name 2 [Ltd.]:

<-- it is still using the spaces to separate out the fields, irrespective of the semi-colon.

This patch fixes it and works splitting properly when semicolons are used, but not splitting based on spaces.